### PR TITLE
Replace Zend HTTP composer requirement with Laminas HTTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "shipperhq/library-graphql",
   "description": "ShipperHQ GraphQL Library",
   "type": "magento2-library",
-  "version": "20.3.0",
+  "version": "20.3.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   ],
   "require": {
     "php": "~7.1",
-    "zendframework/zend-http": "~2.0",
+    "laminas/laminas-zendframework-bridge": "^1.0",
+    "laminas/laminas-http": "^2.15",
     "netresearch/jsonmapper": "~1.4"
   },
   "support": {


### PR DESCRIPTION
This will cover currently supported M2 versions.