### PR TITLE
task: remove unused laminas-dependency-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "shipperhq/library-graphql",
     "description": "ShipperHQ GraphQL Library",
     "type": "magento2-library",
-    "version": "20.4.4",
+    "version": "20.4.5",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -21,7 +21,6 @@
         "php": "~7.1 || ~8.1",
         "laminas/laminas-http": "~2.0",
         "netresearch/jsonmapper": "^4.0",
-        "laminas/laminas-dependency-plugin": "^1.0 | ^2.0",
         "ext-json": "*"
     },
     "support": {


### PR DESCRIPTION
# Description

With the changes introduced by PR #3, this dependency should have been removed as it is no longer being used. While it being unused is normally not a big issue, the problem with this dependency is that it is locked to the LTS version of composer:

https://github.com/laminas/laminas-dependency-plugin/blob/8bb101df30a88fe3d31236eb0fab1dda9d04abd2/composer.json#L17

This presents a few issues:

 1. Adobe Commerce Cloud installs must lock their composer version in `.magento.app.yaml` to `>= 2.2 <2.3`
 2. Environments that utilize GitHub Hosted Mend Renovate for automatic dependency management will fail as it uses the latest non-LTS release of composer (and the version cannot be locked).
 3. Adobe Commerce 2.4.7 will require composer `2.5.x` as the [minimum supported version](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html?lang=en) which will cause upgrades to fail due to this transitive dependency being locked.